### PR TITLE
Remove unnecessary header navigation and dark mode toggle

### DIFF
--- a/frontend/app/components/Layout.test.tsx
+++ b/frontend/app/components/Layout.test.tsx
@@ -44,11 +44,11 @@ describe('Layout Component', () => {
       expect(screen.getByAltText('MD-Todo Logo')).toBeInTheDocument();
     });
 
-    it('centers the logo and title in header', () => {
+    it('aligns logo and title to the left in header', () => {
       render(<Layout>{mockChildren}</Layout>);
       
       const headerContent = screen.getByRole('banner').querySelector('div');
-      expect(headerContent).toHaveClass('justify-center');
+      expect(headerContent).toHaveClass('justify-start');
     });
 
     it('applies sticky positioning to header', () => {

--- a/frontend/app/components/Layout.test.tsx
+++ b/frontend/app/components/Layout.test.tsx
@@ -1,39 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 import { Layout } from './Layout';
 
 // Props for mock component
 const mockChildren = <div data-testid="test-children">Test Children</div>;
 
 describe('Layout Component', () => {
-  beforeEach(() => {
-    // Reset viewport size
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 1024,
-    });
-    Object.defineProperty(window, 'innerHeight', {
-      writable: true,
-      configurable: true,
-      value: 768,
-    });
-    
-    // Mock localStorage
-    const localStorageMock = {
-      getItem: vi.fn(),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-      clear: vi.fn(),
-    };
-    Object.defineProperty(window, 'localStorage', {
-      value: localStorageMock,
-    });
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
 
   describe('Basic Layout Structure', () => {
     it('renders header, main, and footer sections', () => {
@@ -72,11 +44,11 @@ describe('Layout Component', () => {
       expect(screen.getByAltText('MD-Todo Logo')).toBeInTheDocument();
     });
 
-    it('includes navigation menu', () => {
+    it('centers the logo and title in header', () => {
       render(<Layout>{mockChildren}</Layout>);
       
-      const navigation = screen.getByRole('navigation');
-      expect(navigation).toHaveAttribute('aria-label', 'Main navigation');
+      const headerContent = screen.getByRole('banner').querySelector('div');
+      expect(headerContent).toHaveClass('justify-center');
     });
 
     it('applies sticky positioning to header', () => {
@@ -88,58 +60,6 @@ describe('Layout Component', () => {
   });
 
   describe('Responsive Design', () => {
-    it('shows mobile menu button on small screens', () => {
-      // Simulate mobile size
-      Object.defineProperty(window, 'innerWidth', {
-        writable: true,
-        configurable: true,
-        value: 375,
-      });
-      
-      render(<Layout>{mockChildren}</Layout>);
-      
-      expect(screen.getByTestId('mobile-menu-button')).toBeInTheDocument();
-      expect(screen.getByLabelText('Open navigation menu')).toBeInTheDocument();
-    });
-
-    it('hides mobile menu button on large screens', () => {
-      // Simulate desktop size
-      Object.defineProperty(window, 'innerWidth', {
-        writable: true,
-        configurable: true,
-        value: 1200,
-      });
-      
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const mobileButton = screen.queryByTestId('mobile-menu-button');
-      expect(mobileButton).toHaveClass('md:hidden');
-    });
-
-    it('toggles mobile menu visibility when button is clicked', () => {
-      // Simulate mobile size
-      Object.defineProperty(window, 'innerWidth', {
-        writable: true,
-        configurable: true,
-        value: 375,
-      });
-      
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const mobileMenuButton = screen.getByTestId('mobile-menu-button');
-      const mobileMenu = screen.getByTestId('mobile-menu');
-      
-      // Initially hidden
-      expect(mobileMenu).toHaveClass('hidden');
-      
-      // Show on button click
-      fireEvent.click(mobileMenuButton);
-      expect(mobileMenu).not.toHaveClass('hidden');
-      
-      // Hide on second click
-      fireEvent.click(mobileMenuButton);
-      expect(mobileMenu).toHaveClass('hidden');
-    });
 
     it('applies responsive grid layout', () => {
       render(<Layout>{mockChildren}</Layout>);
@@ -156,54 +76,6 @@ describe('Layout Component', () => {
     });
   });
 
-  describe('Theme Toggle', () => {
-    it('renders dark mode toggle button', () => {
-      render(<Layout>{mockChildren}</Layout>);
-      
-      expect(screen.getByRole('button', { name: /toggle dark mode/i })).toBeInTheDocument();
-    });
-
-    it('toggles theme when dark mode button is clicked', () => {
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const themeToggle = screen.getByRole('button', { name: /toggle dark mode/i });
-      
-      // Initially light mode
-      expect(document.documentElement).not.toHaveClass('dark');
-      
-      // Switch to dark mode
-      fireEvent.click(themeToggle);
-      expect(document.documentElement).toHaveClass('dark');
-      
-      // Switch back to light mode
-      fireEvent.click(themeToggle);
-      expect(document.documentElement).not.toHaveClass('dark');
-    });
-
-    it('persists theme preference in localStorage', () => {
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const themeToggle = screen.getByRole('button', { name: /toggle dark mode/i });
-      fireEvent.click(themeToggle);
-      
-      // Confirm dark theme is applied
-      expect(document.documentElement).toHaveClass('dark');
-    });
-
-    it('loads theme preference from localStorage on mount', () => {
-      // Save dark theme to localStorage
-      const originalGetItem = window.localStorage.getItem;
-      window.localStorage.getItem = vi.fn((key) => key === 'theme' ? 'dark' : null);
-      
-      render(<Layout>{mockChildren}</Layout>);
-      
-      // Confirm dark theme is applied
-      expect(document.documentElement).toHaveClass('dark');
-      
-      // Restore original function
-      window.localStorage.getItem = originalGetItem;
-    });
-  });
 
   describe('Accessibility', () => {
     it('includes skip to main content link', () => {
@@ -222,22 +94,6 @@ describe('Layout Component', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('MD-Todo');
     });
 
-    it('has proper ARIA attributes for navigation', () => {
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const navigation = screen.getByRole('navigation');
-      expect(navigation).toHaveAttribute('aria-label', 'Main navigation');
-    });
-
-    it('provides appropriate focus management for mobile menu', () => {
-      render(<Layout>{mockChildren}</Layout>);
-      
-      const mobileMenuButton = screen.getByTestId('mobile-menu-button');
-      expect(mobileMenuButton).toHaveAttribute('aria-expanded', 'false');
-      
-      fireEvent.click(mobileMenuButton);
-      expect(mobileMenuButton).toHaveAttribute('aria-expanded', 'true');
-    });
 
     it('includes proper role attributes for semantic structure', () => {
       render(<Layout>{mockChildren}</Layout>);
@@ -245,7 +101,6 @@ describe('Layout Component', () => {
       expect(screen.getByRole('banner')).toBeInTheDocument(); // header
       expect(screen.getByRole('main')).toBeInTheDocument(); // main
       expect(screen.getByRole('contentinfo')).toBeInTheDocument(); // footer
-      expect(screen.getByRole('navigation')).toBeInTheDocument(); // nav
     });
   });
 
@@ -277,11 +132,10 @@ describe('Layout Component', () => {
     it('uses semantic HTML elements for better performance', () => {
       render(<Layout>{mockChildren}</Layout>);
       
-      // Semantic elements like header, main, footer, nav are used
+      // Semantic elements like header, main, footer are used
       expect(screen.getByRole('banner').tagName).toBe('HEADER');
       expect(screen.getByRole('main').tagName).toBe('MAIN');
       expect(screen.getByRole('contentinfo').tagName).toBe('FOOTER');
-      expect(screen.getByRole('navigation').tagName).toBe('NAV');
     });
 
     it('provides proper meta tags for SEO', () => {

--- a/frontend/app/components/Layout.tsx
+++ b/frontend/app/components/Layout.tsx
@@ -1,39 +1,10 @@
-import { useState, useEffect, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 export function Layout({ children }: LayoutProps) {
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-
-  // Load theme preference from localStorage on mount
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
-      setIsDarkMode(true);
-      document.documentElement.classList.add('dark');
-    }
-  }, []);
-
-  // Toggle theme and persist to localStorage
-  const toggleTheme = () => {
-    const newTheme = !isDarkMode;
-    setIsDarkMode(newTheme);
-    
-    if (newTheme) {
-      document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-    }
-  };
-
-  const toggleMobileMenu = () => {
-    setIsMobileMenuOpen(!isMobileMenuOpen);
-  };
 
   return (
     <div data-testid="app-container" className="container mx-auto px-4">
@@ -48,7 +19,7 @@ export function Layout({ children }: LayoutProps) {
 
       {/* Header */}
       <header role="banner" className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex items-center justify-between h-16 md:h-20">
+        <div className="flex items-center justify-center h-16 md:h-20">
           {/* Logo and Title */}
           <div className="flex items-center space-x-3">
             <img
@@ -59,83 +30,6 @@ export function Layout({ children }: LayoutProps) {
             <h1 className="text-lg md:text-xl lg:text-2xl font-bold text-gray-900 dark:text-white">
               MD-Todo
             </h1>
-          </div>
-
-          {/* Desktop Navigation */}
-          <nav role="navigation" aria-label="Main navigation" data-testid="desktop-navigation" className="hidden md:flex items-center space-x-6">
-            <a href="/" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white" tabIndex={0}>
-              Home
-            </a>
-            <a href="/todos" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white" tabIndex={0}>
-              Todos
-            </a>
-            <a href="/about" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white" tabIndex={0}>
-              About
-            </a>
-          </nav>
-
-          {/* Theme Toggle and Mobile Menu Button */}
-          <div className="flex items-center space-x-3">
-            {/* Dark Mode Toggle */}
-            <button
-              onClick={toggleTheme}
-              aria-label="Toggle dark mode"
-              className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
-            >
-              {isDarkMode ? (
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-                </svg>
-              ) : (
-                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-                </svg>
-              )}
-            </button>
-
-            {/* Mobile Menu Button */}
-            <button
-              onClick={toggleMobileMenu}
-              data-testid="mobile-menu-button"
-              aria-label="Open navigation menu"
-              aria-expanded={isMobileMenuOpen}
-              className="md:hidden p-2 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
-            >
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        {/* Mobile Menu */}
-        <div
-          data-testid="mobile-menu"
-          aria-hidden={!isMobileMenuOpen}
-          className={`md:hidden border-t border-gray-200 dark:border-gray-700 ${isMobileMenuOpen ? 'block' : 'hidden'}`}
-        >
-          <div data-testid="mobile-touch-navigation" className="px-4 py-4 space-y-4">
-            <a
-              href="/"
-              className="block text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white min-h-[44px] flex items-center"
-              tabIndex={0}
-            >
-              Home
-            </a>
-            <a
-              href="/todos"
-              className="block text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white min-h-[44px] flex items-center"
-              tabIndex={0}
-            >
-              Todos
-            </a>
-            <a
-              href="/about"
-              className="block text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white min-h-[44px] flex items-center"
-              tabIndex={0}
-            >
-              About
-            </a>
           </div>
         </div>
       </header>

--- a/frontend/app/components/Layout.tsx
+++ b/frontend/app/components/Layout.tsx
@@ -19,7 +19,7 @@ export function Layout({ children }: LayoutProps) {
 
       {/* Header */}
       <header role="banner" className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex items-center justify-center h-16 md:h-20">
+        <div className="flex items-center justify-start h-16 md:h-20">
           {/* Logo and Title */}
           <div className="flex items-center space-x-3">
             <img

--- a/frontend/app/root.test.tsx
+++ b/frontend/app/root.test.tsx
@@ -53,16 +53,6 @@ describe("Root Layout Component", () => {
       expect(screen.getByText("MD-Todo")).toBeInTheDocument();
     });
 
-    it("renders navigation menu", () => {
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm navigation menu is displayed
-      expect(screen.getByRole("navigation")).toBeInTheDocument();
-    });
 
     it("renders logo image with proper alt text", () => {
       render(
@@ -152,42 +142,7 @@ describe("Root Layout Component", () => {
       expect(container).toHaveClass("container", "mx-auto", "px-4");
     });
 
-    it("renders mobile-friendly navigation on small screens", () => {
-      // Simulate mobile size viewport
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: 375,
-      });
 
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm mobile navigation is displayed
-      expect(screen.getByTestId("mobile-menu-button")).toBeInTheDocument();
-    });
-
-    it("hides mobile menu button on desktop screens", () => {
-      // Simulate desktop size viewport
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: 1200,
-      });
-
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm mobile menu button has hidden class applied on desktop
-      const mobileButton = screen.getByTestId("mobile-menu-button");
-      expect(mobileButton).toHaveClass("md:hidden");
-    });
 
     it("applies appropriate grid layout for different screen sizes", () => {
       render(
@@ -229,44 +184,6 @@ describe("Root Layout Component", () => {
       expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
     });
 
-    it("provides aria-label for navigation", () => {
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm navigation has appropriate aria-label
-      const navigation = screen.getByRole("navigation");
-      expect(navigation).toHaveAttribute("aria-label", "Main navigation");
-    });
   });
 
-  describe("Theme Support", () => {
-    it("supports dark mode toggle", () => {
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm dark mode toggle button exists
-      expect(
-        screen.getByRole("button", { name: /toggle dark mode/i })
-      ).toBeInTheDocument();
-    });
-
-    it("applies theme classes to body element", () => {
-      render(
-        <AppLayout>
-          <div>Test content</div>
-        </AppLayout>
-      );
-
-      // Confirm Layout component renders correctly
-      expect(
-        screen.getByRole("button", { name: /toggle dark mode/i })
-      ).toBeInTheDocument();
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- Removed Home, Todos, About navigation links from both desktop and mobile header menus
- Removed dark mode toggle button and all related state management functionality
- Simplified header layout with logo and title aligned to the left, creating a cleaner focus on core branding
- Updated Layout component tests to reflect the new simplified structure

## Changes Made
- **Layout.tsx**: Removed navigation links, dark mode toggle, mobile menu functionality, and related state
- **Layout.test.tsx**: Updated tests to match simplified header structure, removed tests for removed functionality
- Header now uses `justify-start` for left-aligned logo/title layout

## Test Plan
- [x] All Layout component tests pass (17/17)
- [x] Application builds successfully without errors
- [x] TypeScript compilation passes
- [x] ESLint passes with no warnings
- [x] Header displays correctly with left-aligned logo and title
- [x] No navigation elements or dark mode toggle present
- [x] Application functionality remains intact

## Impact
This change creates a cleaner, more focused header that emphasizes the application branding without unnecessary navigation clutter. The simplified design improves the user experience by reducing visual noise.

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)