### PR TITLE
Remove unnecessary instructional text from home page

### DIFF
--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -364,7 +364,7 @@ function TodoApp() {
           <p className="text-gray-600 dark:text-gray-400">
             {(todos?.length || 0) === 0
               ? "No todos yet. Create your first todo to get started!"
-              : "Click on checkboxes to mark todos as complete, or use the delete button to remove them."}
+              : ""}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- Remove the instructional text "Click on checkboxes to mark todos as complete, or use the delete button to remove them." from the home page
- Improve UI cleanliness by removing redundant guidance text

## Changes

- Modified `frontend/app/routes/_index.tsx` to remove the instructional text when todos are present
- The text was only shown when todos exist, now shows empty string instead
- Maintains the "No todos yet. Create your first todo to get started\!" message for empty state

## Test plan

- [x] Verify that the home page loads without the instructional text when todos exist
- [x] Confirm that the empty state message still appears when no todos exist
- [x] Check that all other functionality remains intact

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)